### PR TITLE
Fix ambiguous != operator for Swift 6.2

### DIFF
--- a/Sources/Internal/Macro.swift
+++ b/Sources/Internal/Macro.swift
@@ -65,7 +65,7 @@ public struct AutoRegisterableMacro: MemberMacro {
     guard
       patternBindings
         .reduce([], +)
-        .allSatisfy({ $0.typeAnnotation != nil })
+        .allSatisfy({ $0.typeAnnotation != Optional<TypeAnnotationSyntax>.none })
     else {
       let diagnostic = Diagnostic(
         node: Syntax(attribute), message: MacroDiagnostic.requiresTypedDependencies)


### PR DESCRIPTION
## Summary
- Fixes build failure on Xcode 26.4 / Swift 6.2 caused by ambiguous use of `!=` operator at `Sources/Internal/Macro.swift:68`
- In Swift 6.2, `$0.typeAnnotation != nil` is ambiguous because both `Equatable.!=` and `Optional.!=` match
- Disambiguated by comparing against `Optional<TypeAnnotationSyntax>.none` explicitly

## Test plan
- [x] Verified `swift build` succeeds on Xcode 26.4 (Build version 17E192)

🤖 Generated with [Claude Code](https://claude.com/claude-code)