### PR TITLE
Update to Swift 6.3 and SwiftSyntax 603.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.2
+// swift-tools-version:6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 internal import CompilerPluginSupport
@@ -16,9 +16,9 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/num42/swift-macrohelper.git", from: "1.0.1"),
-    .package(url: "https://github.com/num42/swift-macrotester.git", from: "2.2.2"),
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
+    .package(url: "https://github.com/num42/swift-macrohelper.git", from: "1.1.0"),
+    .package(url: "https://github.com/num42/swift-macrotester.git", from: "2.3.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.0"),
   ],
   targets: [
     .macro(


### PR DESCRIPTION
## Summary
- Bump swift-tools-version from 6.2 to 6.3
- Bump SwiftSyntax from 602.0.0 to 603.0.0
- Bump MacroHelper to 1.1.0
- Bump MacroTester to 2.3.0

## Test plan
- [x] `swift build` succeeds on Xcode 26.4
- [x] `swift test` all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)